### PR TITLE
chore: Documentation markdown and files added to build

### DIFF
--- a/build/release/outputFiles.js
+++ b/build/release/outputFiles.js
@@ -7,6 +7,7 @@ const { entry, output } = config;
 
 const files = [
 	'vars.css',
+	'docs',
 ];
 
 for (const destPath in entry) {

--- a/build/webpack.config.build.js
+++ b/build/webpack.config.build.js
@@ -126,10 +126,21 @@ const WebpackConfigBuild = merge(WebpackConfigBase, {
 			},
 		}),
 
-		new CopyWebpackPlugin([{
-			from: 'src/styles/vars.css',
-			to: 'vars.css',
-		}]),
+		new CopyWebpackPlugin([
+			{
+				from: 'src/styles/vars.css',
+				to: 'vars.css',
+			},
+			{
+				from: 'src/components/**/doc/*',
+				globOptions: {
+					dot: true,
+					gitignore: true,
+				},
+				to: 'docs/',
+				transformPath: (targetPath) => targetPath.replace('src/components/', ''),
+			},
+		]),
 
 		new Distsize({
 			filter: (asset) => (

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "files": [
     "utils",
-    "components",
+		"components",
+		"docs",
     "*.{css,css.map}"
   ],
   "os": [

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   },
   "files": [
     "utils",
-		"components",
-		"docs",
+    "components",
+    "docs",
     "*.{css,css.map}"
   ],
   "os": [


### PR DESCRIPTION
**Describe the problem prior to this PR:**
There is no way to access the component markdown documentation.

**Describe the changes in this PR:**
- Uses CopyWebpackPlugin to copy the component documentation folders to a new `/docs` folder on build
- This will allow them to be leveraged by documentation apps

- [x] Distsize has been updated (via `npm run build`)